### PR TITLE
SLACDP22-45: install entity_clone

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "drupal/diff": "^1.0",
     "drupal/duration_field": "^2.0",
     "drupal/easy_breadcrumb": "^2.0",
+    "drupal/entity_clone": "^1.0@beta",
     "drupal/entity_reference_revisions": "^1.9",
     "drupal/environment_indicator": "^4.0",
     "drupal/estimated_read_time": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a05b6709abc0fff54a923f49f687648f",
+    "content-hash": "c54464bb6478d3bb7024747fee10195d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3454,6 +3454,72 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/easy_breadcrumb",
                 "issues": "https://www.drupal.org/project/issues/easy_breadcrumb"
+            }
+        },
+        {
+            "name": "drupal/entity_clone",
+            "version": "1.0.0-beta7",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_clone.git",
+                "reference": "8.x-1.0-beta7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_clone-8.x-1.0-beta7.zip",
+                "reference": "8.x-1.0-beta7",
+                "shasum": "964b72b21a7e219cf337743ed5c8850235197594"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "require-dev": {
+                "drupal/entity_browser": "2.x-dev",
+                "drupal/entity_usage": "2.x-dev",
+                "drupal/paragraphs": "^1.0",
+                "drupal/search_api": "~1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-beta7",
+                    "datestamp": "1663573486",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "colan",
+                    "homepage": "https://www.drupal.org/user/58704"
+                },
+                {
+                    "name": "NickDickinsonWilde",
+                    "homepage": "https://www.drupal.org/user/3094661"
+                },
+                {
+                    "name": "Rajeshreeputra",
+                    "homepage": "https://www.drupal.org/user/3418561"
+                },
+                {
+                    "name": "Upchuk",
+                    "homepage": "https://www.drupal.org/user/1885838"
+                },
+                {
+                    "name": "vpeltot",
+                    "homepage": "https://www.drupal.org/user/1361586"
+                }
+            ],
+            "description": "Add a clone action for all entities.",
+            "homepage": "https://drupal.org/project/entity_clone",
+            "support": {
+                "source": "https://git.drupalcode.org/project/entity_clone"
             }
         },
         {
@@ -17455,6 +17521,7 @@
     "stability-flags": {
         "drupal/block_field": 5,
         "drupal/conditional_fields": 15,
+        "drupal/entity_clone": 10,
         "drupal/gin": 10,
         "drupal/gin_toolbar": 10,
         "drupal/inline_entity_form": 5,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -33,6 +33,7 @@ module:
   dynamic_page_cache: 0
   easy_breadcrumb: 0
   editor: 0
+  entity_clone: 0
   entity_reference_revisions: 0
   environment_indicator: 0
   environment_indicator_ui: 0


### PR DESCRIPTION
https://forumone.atlassian.net/browse/SLACDP22-45

`ddev composer install`
`ddev drush cim -y`

`entity_clone` is installed.  Content can be cloned, including attached entities on the node.