### PR TITLE
SLACDP22-103: install and config node_revision_delete

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
     "drupal/migrate_manifest": "^3.0",
     "drupal/migrate_tools": "^6.0",
     "drupal/migrate_upgrade": "^4",
+    "drupal/node_revision_delete": "^1.0@RC",
     "drupal/oembed_providers": "^2.0",
     "drupal/pantheon_advanced_page_cache": "^2.0",
     "drupal/paragraphs": "^1.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a05b6709abc0fff54a923f49f687648f",
+    "content-hash": "7efc95b75b02dfc6cea3743d163f6093",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5342,6 +5342,83 @@
                 "source": "https://git.drupalcode.org/project/migrate_upgrade",
                 "issues": "https://www.drupal.org/project/issues/migrate_upgrade",
                 "slack": "#migrate"
+            }
+        },
+        {
+            "name": "drupal/node_revision_delete",
+            "version": "1.0.0-rc5",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/node_revision_delete.git",
+                "reference": "8.x-1.0-rc5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/node_revision_delete-8.x-1.0-rc5.zip",
+                "reference": "8.x-1.0-rc5",
+                "shasum": "71c77c1c8ee48c9797995bf519ec495958413acf"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9.0 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0-rc5",
+                    "datestamp": "1659589844",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Adrian Cid Almaguer (adriancid)",
+                    "homepage": "https://www.drupal.org/u/adriancid",
+                    "email": "adriancid@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Diosbel Mezquía (diosbelmezquia)",
+                    "homepage": "https://www.drupal.org/u/diosbelmezquia",
+                    "email": "dmezquiam@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Robert Ngo (Robert Ngo)",
+                    "homepage": "https://www.drupal.org/u/robert-ngo",
+                    "email": "robertngo.18@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Robert Ngo",
+                    "homepage": "https://www.drupal.org/user/610230"
+                },
+                {
+                    "name": "seanB",
+                    "homepage": "https://www.drupal.org/user/545912"
+                }
+            ],
+            "description": "Track and prune node revisions.",
+            "homepage": "https://www.drupal.org/project/node_revision_delete",
+            "keywords": [
+                "Drupal",
+                "Nodes",
+                "Revisions"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/node_revision_delete",
+                "issues": "https://www.drupal.org/project/issues/node_revision_delete"
             }
         },
         {
@@ -17463,6 +17540,7 @@
         "drupal/maxlength": 5,
         "drupal/media_migration": 15,
         "drupal/migrate_devel": 15,
+        "drupal/node_revision_delete": 5,
         "drupal/rabbit_hole": 10,
         "drupal/rh_media": 10,
         "drupal/style_options": 15,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -80,6 +80,7 @@ module:
   migrate_upgrade: 0
   mysql: 0
   node: 0
+  node_revision_delete: 0
   oembed_providers: 0
   options: 0
   page_cache: 0

--- a/config/sync/node.type.article.yml
+++ b/config/sync/node.type.article.yml
@@ -1,7 +1,19 @@
 uuid: 02e6fec3-3f7f-4440-8405-8e364f0be88b
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - menu_ui
+    - node_revision_delete
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 _core:
   default_config_hash: AeW1SEDgb1OTQACAWGhzvMknMYAJlcZu0jljfeU3oso
 name: Article

--- a/config/sync/node.type.event.yml
+++ b/config/sync/node.type.event.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 name: Event
 type: event
 description: ''

--- a/config/sync/node.type.homepage.yml
+++ b/config/sync/node.type.homepage.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 name: Homepage
 type: homepage
 description: ''

--- a/config/sync/node.type.landing_page.yml
+++ b/config/sync/node.type.landing_page.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 name: 'Landing Page'
 type: landing_page
 description: ''

--- a/config/sync/node.type.media_mention.yml
+++ b/config/sync/node.type.media_mention.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 name: 'Media Mention'
 type: media_mention
 description: ''

--- a/config/sync/node.type.news_article.yml
+++ b/config/sync/node.type.news_article.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 name: 'News Article'
 type: news_article
 description: ''

--- a/config/sync/node.type.news_collection.yml
+++ b/config/sync/node.type.news_collection.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 name: 'News Collection'
 type: news_collection
 description: ''

--- a/config/sync/node.type.page.yml
+++ b/config/sync/node.type.page.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 _core:
   default_config_hash: KuyA4NHPXcmKAjRtwa0vQc2ZcyrUJy6IlS2TAyMNRbc
 name: 'Basic page'

--- a/config/sync/node.type.person.yml
+++ b/config/sync/node.type.person.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 name: Person
 type: person
 description: ''

--- a/config/sync/node.type.resource.yml
+++ b/config/sync/node.type.resource.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 30
+    minimum_age_to_delete: 6
+    when_to_delete: 1
 name: Resource
 type: resource
 description: ''

--- a/config/sync/node_revision_delete.settings.yml
+++ b/config/sync/node_revision_delete.settings.yml
@@ -1,0 +1,11 @@
+_core:
+  default_config_hash: Cq0qEqvsPlEVfrCpF0VRzK4MFQhRHzqncneoTEKHXUc
+delete_newer: false
+node_revision_delete_cron: 50
+node_revision_delete_time: -1
+node_revision_delete_minimum_age_to_delete_time:
+  max_number: 12
+  time: months
+node_revision_delete_when_to_delete_time:
+  max_number: 12
+  time: months

--- a/config/sync/ultimate_cron.job.node_revision_delete_cron.yml
+++ b/config/sync/ultimate_cron.job.node_revision_delete_cron.yml
@@ -1,0 +1,17 @@
+uuid: 256b5fb3-ee5a-4000-aa67-707668b54dec
+langcode: en
+status: true
+dependencies:
+  module:
+    - node_revision_delete
+title: 'Default cron handler'
+id: node_revision_delete_cron
+weight: 0
+module: node_revision_delete
+callback: node_revision_delete_cron
+scheduler:
+  id: simple
+launcher:
+  id: serial
+logger:
+  id: database


### PR DESCRIPTION
https://forumone.atlassian.net/browse/SLACDP22-103

`ddev composer install`
`ddev drush cim -y`

Node Revision Delete is installed and configured for all content types.  We'll probably be deleting a lot of those content types anyway, but just to be sure, they're all configged the same.