### PR TITLE
update publications - Tags & name display

### DIFF
--- a/config/sync/core.entity_view_display.node.publication.default.yml
+++ b/config/sync/core.entity_view_display.node.publication.default.yml
@@ -29,6 +29,7 @@ dependencies:
     - link
     - name
     - options
+    - slac_helper
     - text
     - user
 id: node.publication.default
@@ -53,7 +54,7 @@ content:
     type: name_default
     label: above
     settings:
-      format: short_full
+      format: full
       markup: none
       list_format: ''
       link_target: ''
@@ -192,7 +193,7 @@ content:
     weight: 9
     region: content
   field_tags:
-    type: entity_reference_label
+    type: slac_tag
     label: above
     settings:
       link: true


### PR DESCRIPTION
for 125 - update the publications detail page to show Tags, not Topics. I also remember seeing a QA comment about the name only displaying first/last when it should probably be full (including middle initials etc) so I've updated that.